### PR TITLE
Adds a new workflow, :test for generating fake responses

### DIFF
--- a/src/cognitect/aws/client/api.clj
+++ b/src/cognitect/aws/client/api.clj
@@ -64,13 +64,18 @@
                           Valid values:
                           - :cognitect.aws.alpha.workflow/default (default)
                           - :cognitect.aws.alpha.workflow/presigned-url
+                          - :cognitect.aws.alpha.workflow/test
+                          When `:test`, don't send the request to AWS, and return a fake response using the API's response spec
+
+  :test-handler         - optional. When in :test mode, a middleware function [handler -> [req -> resp]], the request map. Call the handler to get the default behavior
+
 
   By default, all clients use shared http-client, credentials-provider, and
   region-provider instances which use a small collection of daemon threads.
 
   Alpha. Subject to change."
   [{:keys [api region region-provider retriable? backoff credentials-provider endpoint endpoint-override
-           http-client workflow]
+           http-client workflow test-handler]
     :or   {endpoint-override {}}}]
   (when (string? endpoint-override)
     (log/warn
@@ -98,7 +103,8 @@
                                    (region/basic-region-provider region)))
     :credentials-provider credentials-provider
     :validate-requests?   (atom nil)
-    :workflow             workflow}))
+    :workflow             workflow
+    :test-handler         test-handler}))
 
 (defn default-http-client
   "Create an http-client to share across multiple aws-api clients."
@@ -121,6 +127,9 @@
                           Valid values:
                           - :cognitect.aws.alpha.workflow/default (default)
                           - :cognitect.aws.alpha.workflow/presigned-url
+                          - :cognitect.aws.alpha.workflow/test
+
+  :test-handler          - optional when using the test workflow, a function of [context request -> response] to change test behavior
 
   After invoking (cognitect.aws.client.api/validate-requests true), validates
   :request in op-map.

--- a/src/cognitect/aws/client/api/async.clj
+++ b/src/cognitect/aws/client/api/async.clj
@@ -51,7 +51,8 @@
 (def ^{:private true :skip-wiki true} workflow-stacks
   {:cognitect.aws.alpha.workflow/default             default-stack/default-stack
    :cognitect.aws.alpha.workflow/presigned-url       presigned-url-stack/presigned-url-stack
-   :cognitect.aws.alpha.workflow/fetch-presigned-url presigned-url-stack/fetch-presigned-url-stack})
+   :cognitect.aws.alpha.workflow/fetch-presigned-url presigned-url-stack/fetch-presigned-url-stack
+   :cognitect.aws.alpha.workflow/test                default-stack/test-stack})
 
 (defn invoke
   "Async version of cognitect.aws.client.api/invoke. Returns
@@ -65,7 +66,7 @@
   [client op-map]
   (let [workflow-steps                       (or (:workflow-steps op-map) ;; internal use only
                                                  (get workflow-stacks
-                                                      (or (:workflow op-map) (:workflow client))
+                                                      (or (:workflow op-map) (-> client .info :workflow))
                                                       default-stack/default-stack))
         result-chan                          (or (:ch op-map) (a/promise-chan))
         {:keys [api retriable? backoff]} (client/-get-info client)


### PR DESCRIPTION
Adds a new option to the client constructor, enabling test mode:

```clojure
(def s3-test (aws/client {:api :s3 :workflow :cognitect.aws.alpha.workflow/test :test-handler (genesis.providers.aws.s3-test/test-handler)}))
#'user/s3-test
user> (aws/invoke s3-test {:op :CreateBucket :request {:Bucket "bogus"}})
{:Location "2TD0H0h14K8z3qE7U"}
```

The test mode doesn't send requests to AWS, and uses the API specs to generate a fake response.

The upside of this is that griffin.aws.test-client is no longer necessary, and we no longer need to `with-redefs [aws/invoke ]`, which makes it significantly easier to test nested resources, where e.g. testing IAM group membership (which requires creating both a User and a Group before you can test adding a user to a group)

See `./test/genesis/providers/aws_test` calling `with-test-client`. That redef resets the test handler state, which makes nesting properties impossible. With this change, we can pass the test client into the resource constructor, and composability improves